### PR TITLE
Remove hypens from dimension names to prevent Neo error in hierarchy

### DIFF
--- a/recipe/data.go
+++ b/recipe/data.go
@@ -800,7 +800,7 @@ var BuisInvestGFCG = Response{
 					IsHierarchy: true,
 				}, {
 					ID:          "business-investment-instrument-asset",
-					Name:        "instrument-asset",
+					Name:        "instrumentasset",
 					HRef:        "http://localhost:22400/code-lists/business-investment-instrument-asset",
 					IsHierarchy: false,
 				}, {
@@ -845,7 +845,7 @@ var BuisInvestCapitalFormation = Response{
 					IsHierarchy: true,
 				}, {
 					ID:          "business-investment-instrument-asset",
-					Name:        "instrument-asset",
+					Name:        "instrumentasset",
 					HRef:        "http://localhost:22400/code-lists/business-investment-instrument-asset",
 					IsHierarchy: false,
 				}, {


### PR DESCRIPTION
### What

The name gets used as a variable name in a neo query in the hierarchy api, this cannot contain hyphens.

### How to review

check it solves problem

### Who can review

anyone