### PR TITLE
Fix api routing to include /recipes/{id} and re-add old handler

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,6 +44,7 @@ func NewRecipeAPI(ctx context.Context, cfg config.Configuration, router *mux.Rou
 
 	api.get("/health", api.HealthCheck)
 	api.get("/recipes", api.RecipeListHandler)
+	api.get("/recipes/{id}", api.RecipeHandler)
 	return api
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/ONSdigital/dp-recipe-api/recipe"
 	"github.com/ONSdigital/log.go/log"
+	"github.com/gorilla/mux"
 )
 
 //RecipeListHandler - get all recipes
@@ -32,6 +34,40 @@ func (api *RecipeAPI) RecipeListHandler(w http.ResponseWriter, req *http.Request
 	b, err := json.Marshal(list)
 	if err != nil {
 		log.Event(req.Context(), "error returned from json marshall", log.ERROR, log.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+//RecipeHandler as existed in the hardcoded-only version of this service.
+func (api *RecipeAPI) RecipeHandler(w http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	recipeID := vars["id"]
+	logD := log.Data{"recipe_id": recipeID}
+
+	var r recipe.Response
+	found := false
+
+	for _, item := range recipe.FullList.Items {
+		if item.ID == recipeID {
+			r = item
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		log.Event(req.Context(), "recipe not found", log.ERROR, log.Error(errors.New("recipe not found")), logD)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		log.Event(req.Context(), "error returned from json marshall", log.ERROR, log.Error(err), logD)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
### What

We've lost a handler so it needs to be put back

### How to review

Check that calls to /recipes/id return data
Check the Import API can now create jobs

### Who can review

anyone