### PR TITLE
Add function 'AddAllRecipes' to copy from data.go to mongo

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -57,6 +57,9 @@ func NewRecipeAPI(ctx context.Context, cfg config.Configuration, router *mux.Rou
 	api.get("/health", api.HealthCheck)
 	api.get("/recipes", api.RecipeListHandler)
 	api.get("/recipes/{id}", api.RecipeHandler)
+	if api.EnableMongoImport {
+		api.Router.HandleFunc("/allrecipes", api.AddAllRecipeHandler).Methods("POST")
+	}
 	return api
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -100,3 +100,16 @@ func (api *RecipeAPI) HealthCheck(w http.ResponseWriter, req *http.Request) {
 	// Set status to 200 OK
 	w.WriteHeader(200)
 }
+
+//AddAllRecipeHandler - Adds all the recipes from data.go to the mongo database
+func (api *RecipeAPI) AddAllRecipeHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	for _, item := range recipe.FullList.Items {
+		err := api.dataStore.Backend.AddRecipe(item)
+		if err != nil {
+			log.Event(ctx, "error in adding all recipes to mongo from data.go", log.ERROR, log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -141,3 +141,42 @@ func TestGetRecipeReturnsError(t *testing.T) {
 		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 1)
 	})
 }
+
+func TestAddAllRecipesReturnsOK(t *testing.T) {
+	t.Parallel()
+	Convey("A successful request to add all recipes to mongo returns 200 OK response", t, func() {
+		r := httptest.NewRequest("POST", "http://localhost:22300/allrecipes", nil)
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			AddRecipeFunc: func(item recipe.Response) error {
+				return nil
+			},
+		}
+
+		api := GetAPIWithMocks(mockedDataStore)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusOK)
+		So(len(mockedDataStore.AddRecipeCalls()), ShouldEqual, len(recipe.FullList.Items))
+
+	})
+}
+
+func TestAddAllRecipesReturnsError(t *testing.T) {
+	t.Parallel()
+	Convey("When the api cannot add all recipes to mongo return an internal server error", t, func() {
+		r := httptest.NewRequest("POST", "http://localhost:22300/allrecipes", nil)
+		w := httptest.NewRecorder()
+		mockedDataStore := &storetest.StorerMock{
+			AddRecipeFunc: func(item recipe.Response) error {
+				return errs.ErrInternalServer
+			},
+		}
+
+		api := GetAPIWithMocks(mockedDataStore)
+		api.Router.ServeHTTP(w, r)
+
+		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		So(len(mockedDataStore.AddRecipeCalls()), ShouldEqual, 1)
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ func Get() (*Configuration, error) {
 			Collection:        "recipes",
 			Database:          "recipes",
 			EnableMongoData:   false,
-			EnableMongoImport: false,
+			EnableMongoImport: true,
 		},
 	}
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -74,3 +74,11 @@ func (m *Mongo) GetRecipe(id string) (*recipe.Response, error) {
 
 	return &recipe, nil
 }
+
+//AddRecipe adds a recipe document
+func (m *Mongo) AddRecipe(item recipe.Response) error {
+	s := m.Session.Copy()
+	defer s.Close()
+	_, err := s.DB(m.Database).C(m.Collection).UpsertId(item.ID, item)
+	return err
+}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -17,4 +17,5 @@ type DataStore struct {
 type Storer interface {
 	GetRecipes(ctx context.Context) ([]recipe.Response, error)
 	GetRecipe(id string) (*recipe.Response, error)
+	AddRecipe(item recipe.Response) error
 }


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Add "AddRecipe" to mongo package to add recipe
- Add "AddAllRecipeHandler" to use "AddRecipe" function to transfer all recipes to mongo
- Mock to test the functionality

**Previous PR linked with this new PR**
_Mongo Migration: Add handler to transfer all recipes to mongo from data.go_ (https://github.com/ONSdigital/dp-recipe-api/pull/117)

### How to review

**Describe the steps required to test the changes.**
Run the tests in the handlers_test.go for "AddAllRecipes"

### Who can review

**Describe who worked on the changes, so that other people can review.**
Justin worked on the changes
