### PR TITLE
Instantiate Mongo with enableMongoImport flag on

### DIFF
--- a/cmd/dp-recipe-api/main.go
+++ b/cmd/dp-recipe-api/main.go
@@ -67,6 +67,7 @@ func main() {
 
 	//Feature Flag for Mongo Connection
 	enableMongoData := cfg.MongoConfig.EnableMongoData
+	enableMongoImport := cfg.MongoConfig.EnableMongoImport
 
 	datastore := &store.DataStore{Backend: nil}
 
@@ -77,7 +78,7 @@ func main() {
 	}
 
 	var err error
-	if enableMongoData {
+	if enableMongoData || enableMongoImport {
 
 		mongodb.Session, err = mongodb.Init()
 		if err != nil {
@@ -103,7 +104,9 @@ func main() {
 			log.Event(ctx, "failed to add mongoDB checker", log.ERROR, log.Error(err))
 			os.Exit(1)
 		}
-	} else {
+	}
+
+	if !enableMongoData {
 		log.Event(ctx, "using recipes from data.go", log.INFO, log.Data{
 			"bind_address": cfg.BindAddr,
 		})


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
When `ENABLE_MONGO_IMPORT` flag is enabled, it also now instantiate mongo
Also ensures that log message is given to inform retrieval of data from data.go file when `ENABLE_MONGO_DATA` is disabled

This will not change the existing functionality as the flag only enables one endpoint (adding all recipes (migration process)) which uses mongo but at the same time, enabling this feature flag did not instantiate mongo before. But mongo is now instantiated when `ENABLE_MONGO_IMPORT` flag is enabled as well.

The existing endpoints, such as get recipes and get recipe by id, still retrieves data from the data.go file and not from mongo. This will only be changed if `ENABLE_MONGO_DATA` is enabled and this flag is disabled until migration process is complete.

### How to review

**Describe the steps required to test the changes.**
1. Run unit tests to check if they pass
2. Can change `ENABLE_MONGO_IMPORT` to true and test locally
Run `make debug` and check if mongo is running but at the same time, the recipes are still being retrieved from data.go. Just need to check the log messages when run to check. 

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone