### PR TITLE
2 new recipes for weekly deaths

### DIFF
--- a/recipe/data.go
+++ b/recipe/data.go
@@ -18,7 +18,8 @@ var FullList = List{
 		TaxBenefitStats, GenerationalIncome, HousePrices, PrivateHousingRentalPrices, OPSSMembership, OPSSRates, CrimeAccommodation,
 		CrimeOffences, KnifeCrime, InternalMigrationLA, Migration401AGQ, Migration401AG1, Migration401AG2, Migration402, BuisInvestGFCG,
 		BuisInvestCapitalFormation, UKBusinessIndustryGeography, OverseasTravelTourism, ConstructionMonthly, ConstructionYearsQuarters, FamiliesAndHouseholds, 
-		ParentsCountryOfBirth, LifeExpectancy, ChildMortality, Suicides, DrugRelatedDeaths, WeeklyDeathsRegion, WeeklyDeathsAgeSex, MonthlyDeaths, SexualOrientation,
+		ParentsCountryOfBirth, LifeExpectancy, ChildMortality, Suicides, DrugRelatedDeaths, WeeklyDeathsRegion, WeeklyDeathsAgeSex, WeeklyDeathsLocalAuthority, 
+		WeeklyDeathsHealthBoard, MonthlyDeaths, SexualOrientation,
 		Census1961, Census1961SH01, Census1961SH02, Census1961SH03, Census1961SH04, Census1961SH05, Census1961SH06, Census1961SH07, Census1961SH08,
 		Census1961SH09, Census1961SH10, Census1961SH11, Census1961SH12, Census1961SH13, Census1961SH14, Census1961SH15, Census1961ST01, Census1961ST02,
 		Census1961ST03, Census1961ST04, Census1961ST05, Census1961ST06, Census1961ST07, Census1961ST08, Census1961ST09, Census1961SC11, Census1961SC13, Census1961SC22},
@@ -4323,6 +4324,106 @@ var WeeklyDeathsAgeSex = Response{
 					ID:          "recorded-deaths",
 					Name:        "deaths",
 					HRef:        "http://localhost:22400/code-lists/recorded-deaths",
+					IsHierarchy: false,
+				},
+			},
+		},
+	},
+}
+
+// Death registrations and occurrences by local authority and place of death
+var WeeklyDeathsLocalAuthority = Response{
+	ID:     "944e6132-15d4-4da7-8c58-b87c6d3a4633",
+	Alias:  "Death registrations and occurrences by local authority and place of death",
+	Format: "v4",
+	InputFiles: []file{
+		{"WeeklyDeathsLocalAuthority"},
+	},
+	OutputInstances: []instance{
+		{
+			DatasetID: "weekly-deaths-local-authority",
+			Editions:  []string{"time-series"},
+			Title:     "Death registrations and occurrences by local authority and place of death",
+			CodeLists: []CodeList{
+				{
+					ID:          "calendar-years",
+					Name:        "time",
+					HRef:        "http://localhost:22400/code-lists/calendar-years",
+					IsHierarchy: false,
+				}, {
+					ID:          "admin-geography",
+					Name:        "geography",
+					HRef:        "http://localhost:22400/code-lists/admin-geography",
+					IsHierarchy: true,
+				}, {
+					ID:          "week-number",
+					Name:        "week",
+					HRef:        "http://localhost:22400/code-lists/week-number",
+					IsHierarchy: false,
+				}, {
+					ID:          "cause-of-death",
+					Name:        "causeofdeath",
+					HRef:        "http://localhost:22400/code-lists/cause-of-death",
+					IsHierarchy: false,
+				}, {
+					ID:          "place-of-death",
+					Name:        "placeofdeath",
+					HRef:        "http://localhost:22400/code-lists/place-of-death",
+					IsHierarchy: false,
+				}, {
+					ID:          "registration-or-occurrence",
+					Name:        "registrationoroccurrence",
+					HRef:        "http://localhost:22400/code-lists/registration-or-occurrence",
+					IsHierarchy: false,
+				},
+			},
+		},
+	},
+}
+
+// Death registrations and occurrences by health board and place of death
+var WeeklyDeathsHealthBoard = Response{
+	ID:     "0bfbf3a1-35be-435b-8fe6-b2801ce13a60",
+	Alias:  "Death registrations and occurrences by health board and place of death",
+	Format: "v4",
+	InputFiles: []file{
+		{"WeeklyDeathsHealthBoard"},
+	},
+	OutputInstances: []instance{
+		{
+			DatasetID: "weekly-deaths-health-board",
+			Editions:  []string{"time-series"},
+			Title:     "Death registrations and occurrences by health board and place of death",
+			CodeLists: []CodeList{
+				{
+					ID:          "calendar-years",
+					Name:        "time",
+					HRef:        "http://localhost:22400/code-lists/calendar-years",
+					IsHierarchy: false,
+				}, {
+					ID:          "health-board",
+					Name:        "geography",
+					HRef:        "http://localhost:22400/code-lists/health-board",
+					IsHierarchy: false,
+				}, {
+					ID:          "week-number",
+					Name:        "week",
+					HRef:        "http://localhost:22400/code-lists/week-number",
+					IsHierarchy: false,
+				}, {
+					ID:          "cause-of-death",
+					Name:        "causeofdeath",
+					HRef:        "http://localhost:22400/code-lists/cause-of-death",
+					IsHierarchy: false,
+				}, {
+					ID:          "place-of-death",
+					Name:        "placeofdeath",
+					HRef:        "http://localhost:22400/code-lists/place-of-death",
+					IsHierarchy: false,
+				}, {
+					ID:          "registration-or-occurrence",
+					Name:        "registrationoroccurrence",
+					HRef:        "http://localhost:22400/code-lists/registration-or-occurrence",
 					IsHierarchy: false,
 				},
 			},


### PR DESCRIPTION
### What

Created two new recipes for weekly deaths data, which covers:
- Death registrations and occurrences by local authority and place of death
- Death registrations and occurrences by health board and place of death

### How to review

Sanity check

### Who can review

Anyone
