### PR TITLE
Remove GET endpoints feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ one of:
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                     | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL         | 30s                                    | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | The time taken for the health changes from warning state to critical due to subsystem check failures
-| ENABLE_MONGO_DATA            | false                                  | Enable/disable connection to mongo to retrieve recipes
 | ENABLE_MONGO_IMPORT          | false                                  | Enable/disable transfer of all recipes from flat file to mongo
 | ENABLE_AUTH_IMPORT           | false                                  | Enable/disable importing or updating recipes into mongo depending on when authorisation is added
 

--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,6 @@ var srv *server.Server
 type RecipeAPI struct {
 	dataStore         store.DataStore
 	Router            *mux.Router
-	EnableMongoData   bool
 	EnableMongoImport bool
 	EnableAuthImport  bool
 }
@@ -51,7 +50,6 @@ func NewRecipeAPI(ctx context.Context, cfg config.Configuration, router *mux.Rou
 	api := &RecipeAPI{
 		dataStore:         dataStore,
 		Router:            router,
-		EnableMongoData:   cfg.MongoConfig.EnableMongoData,
 		EnableMongoImport: cfg.MongoConfig.EnableMongoImport,
 		EnableAuthImport:  cfg.MongoConfig.EnableAuthImport,
 	}

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -58,7 +58,6 @@ func GetAPIWithMocks(mockedDataStore store.Storer) *RecipeAPI {
 	ctx := context.Background()
 	cfg, err := config.Get()
 	So(err, ShouldBeNil)
-	cfg.MongoConfig.EnableMongoData = true
 	cfg.MongoConfig.EnableMongoImport = true
 	cfg.MongoConfig.EnableAuthImport = true
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,6 @@ type MongoConfig struct {
 	BindAddr          string `envconfig:"MONGODB_BIND_ADDR"   json:"-"`
 	Collection        string `envconfig:"MONGODB_COLLECTION"`
 	Database          string `envconfig:"MONGODB_DATABASE"`
-	EnableMongoData   bool   `envconfig:"ENABLE_MONGO_DATA"`
 	EnableMongoImport bool   `envconfig:"ENABLE_MONGO_IMPORT"`
 	EnableAuthImport  bool   `envconfig:"ENABLE_AUTH_IMPORT"`
 }
@@ -42,7 +41,6 @@ func Get() (*Configuration, error) {
 			BindAddr:          "localhost:27017",
 			Collection:        "recipes",
 			Database:          "recipes",
-			EnableMongoData:   false,
 			EnableMongoImport: false,
 			EnableAuthImport:  false,
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "recipes")
 				So(cfg.MongoConfig.Database, ShouldEqual, "recipes")
-				So(cfg.MongoConfig.EnableMongoData, ShouldEqual, false)
 				So(cfg.MongoConfig.EnableMongoImport, ShouldEqual, false)
 				So(cfg.MongoConfig.EnableAuthImport, ShouldEqual, false)
 			})


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
Remove the `Enable_Mongo_Data` feature flag as the migration to mongo has been successfully and does not require the previous functionalities anymore

### How to review

**Describe the steps required to test the changes.**
Check code to see if the feature flags have been removed
Also, you can run the API locally and check if the GET endpoints are functioning correctly as there is only one functionality for each GET endpoint now, so either it works or it doesn't. 

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justine made the change