### PR TITLE
Remove migration functionality and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ one of:
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                     | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL         | 30s                                    | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | The time taken for the health changes from warning state to critical due to subsystem check failures
-| ENABLE_MONGO_IMPORT          | false                                  | Enable/disable transfer of all recipes from flat file to mongo
 | ENABLE_AUTH_IMPORT           | false                                  | Enable/disable importing or updating recipes into mongo depending on when authorisation is added
 
 ### Recipe Checker

--- a/api/api.go
+++ b/api/api.go
@@ -17,10 +17,9 @@ var srv *server.Server
 
 //RecipeAPI contains store and features for managing the recipe
 type RecipeAPI struct {
-	dataStore         store.DataStore
-	Router            *mux.Router
-	EnableMongoImport bool
-	EnableAuthImport  bool
+	dataStore        store.DataStore
+	Router           *mux.Router
+	EnableAuthImport bool
 }
 
 //CreateAndInitialiseRecipeAPI create a new RecipeAPI instance based on the configuration provided and starts the HTTP server.
@@ -48,18 +47,14 @@ func CreateAndInitialiseRecipeAPI(ctx context.Context, cfg config.Configuration,
 //NewRecipeAPI create a new Recipe API instance and register the API routes based on the application configuration.
 func NewRecipeAPI(ctx context.Context, cfg config.Configuration, router *mux.Router, dataStore store.DataStore) *RecipeAPI {
 	api := &RecipeAPI{
-		dataStore:         dataStore,
-		Router:            router,
-		EnableMongoImport: cfg.MongoConfig.EnableMongoImport,
-		EnableAuthImport:  cfg.MongoConfig.EnableAuthImport,
+		dataStore:        dataStore,
+		Router:           router,
+		EnableAuthImport: cfg.MongoConfig.EnableAuthImport,
 	}
 
 	api.get("/health", api.HealthCheck)
 	api.get("/recipes", api.RecipeListHandler)
 	api.get("/recipes/{id}", api.RecipeHandler)
-	if api.EnableMongoImport {
-		api.post("/allrecipes", api.AddAllRecipeHandler)
-	}
 	if api.EnableAuthImport {
 		api.post("/recipes", api.AddRecipeHandler)
 		api.post("/recipes/{id}/instances", api.AddInstanceHandler)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -81,19 +81,6 @@ func (api *RecipeAPI) HealthCheck(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(200)
 }
 
-//AddAllRecipeHandler - adds all the recipes from data.go to the mongo database
-func (api *RecipeAPI) AddAllRecipeHandler(w http.ResponseWriter, req *http.Request) {
-	ctx := req.Context()
-	for _, item := range recipe.FullList.Items {
-		err := api.dataStore.Backend.AddRecipe(item)
-		if err != nil {
-			log.Event(ctx, "error in adding all recipes to mongo from data.go", log.ERROR, log.Error(err))
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-	}
-}
-
 //AddRecipeHandler - add a recipe
 func (api *RecipeAPI) AddRecipeHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -58,7 +58,6 @@ func GetAPIWithMocks(mockedDataStore store.Storer) *RecipeAPI {
 	ctx := context.Background()
 	cfg, err := config.Get()
 	So(err, ShouldBeNil)
-	cfg.MongoConfig.EnableMongoImport = true
 	cfg.MongoConfig.EnableAuthImport = true
 
 	return NewRecipeAPI(ctx, *cfg, mux.NewRouter(), store.DataStore{Backend: mockedDataStore})

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -173,45 +173,6 @@ func TestGetRecipeReturnsError(t *testing.T) {
 	})
 }
 
-func TestAddAllRecipesReturnsOK(t *testing.T) {
-	t.Parallel()
-	Convey("A successful request to add all recipes to mongo returns 200 OK response", t, func() {
-		r := httptest.NewRequest("POST", "http://localhost:22300/allrecipes", nil)
-		w := httptest.NewRecorder()
-		mockedDataStore := &storetest.StorerMock{
-			AddRecipeFunc: func(item recipe.Response) error {
-				return nil
-			},
-		}
-
-		api := GetAPIWithMocks(mockedDataStore)
-		api.Router.ServeHTTP(w, r)
-
-		So(w.Code, ShouldEqual, http.StatusOK)
-		So(len(mockedDataStore.AddRecipeCalls()), ShouldEqual, len(recipe.FullList.Items))
-
-	})
-}
-
-func TestAddAllRecipesReturnsError(t *testing.T) {
-	t.Parallel()
-	Convey("When the api cannot add all recipes to mongo return an internal server error", t, func() {
-		r := httptest.NewRequest("POST", "http://localhost:22300/allrecipes", nil)
-		w := httptest.NewRecorder()
-		mockedDataStore := &storetest.StorerMock{
-			AddRecipeFunc: func(item recipe.Response) error {
-				return errs.ErrInternalServer
-			},
-		}
-
-		api := GetAPIWithMocks(mockedDataStore)
-		api.Router.ServeHTTP(w, r)
-
-		So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		So(len(mockedDataStore.AddRecipeCalls()), ShouldEqual, 1)
-	})
-}
-
 func TestAddRecipeReturnsOK(t *testing.T) {
 	t.Parallel()
 	Convey("A successful request to add recipe to mongo returns 200 OK response", t, func() {

--- a/config/config.go
+++ b/config/config.go
@@ -17,11 +17,10 @@ type Configuration struct {
 
 // MongoConfig contains the config required to connect to MongoDB.
 type MongoConfig struct {
-	BindAddr          string `envconfig:"MONGODB_BIND_ADDR"   json:"-"`
-	Collection        string `envconfig:"MONGODB_COLLECTION"`
-	Database          string `envconfig:"MONGODB_DATABASE"`
-	EnableMongoImport bool   `envconfig:"ENABLE_MONGO_IMPORT"`
-	EnableAuthImport  bool   `envconfig:"ENABLE_AUTH_IMPORT"`
+	BindAddr         string `envconfig:"MONGODB_BIND_ADDR"   json:"-"`
+	Collection       string `envconfig:"MONGODB_COLLECTION"`
+	Database         string `envconfig:"MONGODB_DATABASE"`
+	EnableAuthImport bool   `envconfig:"ENABLE_AUTH_IMPORT"`
 }
 
 var cfg *Configuration
@@ -38,11 +37,10 @@ func Get() (*Configuration, error) {
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		MongoConfig: MongoConfig{
-			BindAddr:          "localhost:27017",
-			Collection:        "recipes",
-			Database:          "recipes",
-			EnableMongoImport: false,
-			EnableAuthImport:  false,
+			BindAddr:         "localhost:27017",
+			Collection:       "recipes",
+			Database:         "recipes",
+			EnableAuthImport: false,
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,6 @@ func TestSpec(t *testing.T) {
 				So(cfg.MongoConfig.BindAddr, ShouldEqual, "localhost:27017")
 				So(cfg.MongoConfig.Collection, ShouldEqual, "recipes")
 				So(cfg.MongoConfig.Database, ShouldEqual, "recipes")
-				So(cfg.MongoConfig.EnableMongoImport, ShouldEqual, false)
 				So(cfg.MongoConfig.EnableAuthImport, ShouldEqual, false)
 			})
 		})


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
Remove the feature flag `ENABLE_MONGO_IMPORT`
Remove the `AddAllRecipeHandler` which transfers all the recipes from the flat files to mongo

This feature is not needed anymore as the migration to mongo has been complete and this functionality will not be used in the future

### How to review

**Describe the steps required to test the changes.**
Just check if the functionality and the feature flag has been removed

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin worked on the changes