### PR TITLE
fix index panic when wrapping validation errors in code-lists/instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ DP Recipe API
 
 ### Getting started
 
-This repo contains 2 executables - the recipe API and a recipe checker app.
-The recipe API can be run by running `make debug` and the recipe checker can be
-run by running `make checker` (but has some prerequisites, documented below).
+The recipe API can be run by running `make debug`.
 
 ### Healthcheck
 
@@ -28,6 +26,7 @@ one of:
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                     | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL         | 30s                                    | The time between calling healthcheck endpoints for check subsystems
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | The time taken for the health changes from warning state to critical due to subsystem check failures
+| ZEBEDEE_URL                  | http://localhost:8082                  | The URL to Zebedee (for authentication)
 
 ### Contributing
 

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -81,13 +81,13 @@ func (instance *Instance) validateInstance(ctx context.Context) (missingFields [
 			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx)
 
 			if len(codelistMissingFields) > 0 {
-				for _, mField := range codelistMissingFields {
-					codelistMissingFields[i] = "code-lists[" + strconv.Itoa(i) + "]." + mField
+				for mIndex, mField := range codelistMissingFields {
+					codelistMissingFields[mIndex] = "code-lists[" + strconv.Itoa(i) + "]." + mField
 				}
 			}
 			if len(codelistInvalidFields) > 0 {
-				for _, iField := range codelistInvalidFields {
-					codelistInvalidFields[i] = "code-lists[" + strconv.Itoa(i) + "]." + iField
+				for iIndex, iField := range codelistInvalidFields {
+					codelistInvalidFields[iIndex] = "code-lists[" + strconv.Itoa(i) + "]." + iField
 				}
 			}
 
@@ -173,13 +173,13 @@ func (recipe *Response) ValidateAddRecipe(ctx context.Context) error {
 		for i, instance := range recipe.OutputInstances {
 			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx)
 			if len(instanceMissingFields) > 0 {
-				for _, mField := range instanceMissingFields {
-					instanceMissingFields[i] = "output-instances[" + strconv.Itoa(i) + "]." + mField
+				for mIndex, mField := range instanceMissingFields {
+					instanceMissingFields[mIndex] = "output-instances[" + strconv.Itoa(i) + "]." + mField
 				}
 			}
 			if len(instanceInvalidFields) > 0 {
-				for _, iField := range instanceInvalidFields {
-					instanceInvalidFields[i] = "output-instances[" + strconv.Itoa(i) + "]." + iField
+				for iIndex, iField := range instanceInvalidFields {
+					instanceInvalidFields[iIndex] = "output-instances[" + strconv.Itoa(i) + "]." + iField
 				}
 			}
 			missingFields = append(missingFields, instanceMissingFields...)
@@ -279,13 +279,13 @@ func (recipe *Response) ValidateUpdateRecipe(ctx context.Context) error {
 		for i, instance := range recipe.OutputInstances {
 			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx)
 			if len(instanceMissingFields) > 0 {
-				for _, mField := range instanceMissingFields {
-					instanceMissingFields[i] = "output-instances[" + strconv.Itoa(i) + "]." + mField
+				for mIndex, mField := range instanceMissingFields {
+					instanceMissingFields[mIndex] = "output-instances[" + strconv.Itoa(i) + "]." + mField
 				}
 			}
 			if len(instanceInvalidFields) > 0 {
-				for _, iField := range instanceInvalidFields {
-					instanceInvalidFields[i] = "output-instances[" + strconv.Itoa(i) + "]." + iField
+				for iIndex, iField := range instanceInvalidFields {
+					instanceInvalidFields[iIndex] = "output-instances[" + strconv.Itoa(i) + "]." + iField
 				}
 			}
 			missingFields = append(missingFields, instanceMissingFields...)
@@ -337,13 +337,13 @@ func (instance *Instance) ValidateUpdateInstance(ctx context.Context) error {
 		for i, codelist := range instance.CodeLists {
 			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx)
 			if len(codelistMissingFields) > 0 {
-				for _, mField := range codelistMissingFields {
-					codelistMissingFields[i] = "code-lists[" + strconv.Itoa(i) + "]." + mField
+				for mIndex, mField := range codelistMissingFields {
+					codelistMissingFields[mIndex] = "code-lists[" + strconv.Itoa(i) + "]." + mField
 				}
 			}
 			if len(codelistInvalidFields) > 0 {
-				for _, iField := range codelistInvalidFields {
-					codelistInvalidFields[i] = "code-lists[" + strconv.Itoa(i) + "]." + iField
+				for iIndex, iField := range codelistInvalidFields {
+					codelistInvalidFields[iIndex] = "code-lists[" + strconv.Itoa(i) + "]." + iField
 				}
 			}
 			missingFields = append(missingFields, codelistMissingFields...)

--- a/recipe/recipe_test.go
+++ b/recipe/recipe_test.go
@@ -410,6 +410,17 @@ func TestValidateUpdateRecipe(t *testing.T) {
 			recipe.OutputInstances[0].Title = "test" //Reset
 		})
 
+		// test fix: non-existant instanceMissingFields[1] was assigned to, instead of [0] - causing panic
+		Convey("when any one field of second output-instance update is missing", func() {
+			recipe := Response{OutputInstances: []Instance{createInstance(), createInstance()}}
+			recipe.OutputInstances[1].Title = ""
+			err := recipe.ValidateUpdateRecipe(ctx)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [output-instances[1].title]").Error())
+
+			recipe.OutputInstances[1].Title = "test" //Reset
+		})
+
 	})
 
 	Convey("Successful with no missing fields (nil error returned)", t, func() {
@@ -651,6 +662,17 @@ func TestValidateUpdateInstance(t *testing.T) {
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
 			instance.CodeLists[0].Name = "codelist-test" //Reset
+		})
+
+		// test fix: non-existant codelistMissingFields[1] was assigned to, instead of [0] - causing panic
+		Convey("when there are two code lists and second has error", func() {
+			instance := Instance{CodeLists: []CodeList{createCodeList(), createCodeList()}}
+			instance.CodeLists[1].Name = ""
+			err := instance.ValidateUpdateInstance(ctx)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[1].name]").Error())
+
+			instance.CodeLists[1].Name = "codelist-test" //Reset
 		})
 
 	})


### PR DESCRIPTION
### What

When validation finds an error (missing or invalid field) in a code-list or instance, it wraps (rewrites) the error to indicate which (e.g.) code-list

However, it was using the wrong index value (namely, from the outer loop) which caused a panic when the outer loop index > 1.

e.g.  when validation error [0] is found inside code-list [1], it was assigning the rewritten text for error [0] to error [1], which does not exist, ergo, panic 💥

### How to review

ensure sanity, check tests

### Who can review

Not me.