### PR TITLE
Add import script pre-req for MongoDB shell

### DIFF
--- a/import-recipes/README.md
+++ b/import-recipes/README.md
@@ -1,5 +1,15 @@
 This script enables developers to import recipes to their local MongoDB instance. It assumes that no recipes already exist. If you already have recipes you may get an insert error and need to remove the existing recipes.
 
+### Prerequisites
+
+This script requires the Mongo shell to be installed locally. If you attempt to run the script without MongoDB shell, you will see the error message: `command not found: mongo`
+
+To install the MongoDB shell on a Mac:
+```
+brew tap mongodb/brew
+brew install mongodb-community-shell
+```
+
 ### How to run the utility
 
 Ensure you are in the `import-recipes` directory:


### PR DESCRIPTION
### What

The MongoDB shell is required for running the import script locally. As most developers are using the MongoDB instance in dp-compose (i.e. docker), the shell is not available locally.

Added detail about MongoDB shell being a prerequisite to running the script, with details of how to install it.

### How to review
Review changes

### Who can review
Anyone