### PR TITLE
Feature/add local dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 .DS_Store
 vendor/
+.go/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,9 @@
+FROM golang:1.16-stretch AS base
+
+ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
+
+RUN GOBIN=/bin go get github.com/cespare/reflex
+
+# Map between the working directories of dev and live
+RUN ln -s /go /dp-recipe-api
+WORKDIR /dp-recipe-api

--- a/reflex
+++ b/reflex
@@ -1,0 +1,1 @@
+-s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug

--- a/reflex
+++ b/reflex
@@ -1,1 +1,3 @@
--s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug
+# Watch all files ending in .go, excluding files in `.go` directory or files
+# ending in `_test.go` & run `make debug` when any matching file is changed
+-s -r \.go$ -R ^\.go/ -R _test\.go$ make debug


### PR DESCRIPTION
### What

Added a local dockerfile that can be used with reflex and docker-compose for local dev environment.
Added reflex file that defines regex for files to be watched.

### How to review

Make sure service can still be used as normal.

Test docker-compose Cantabular import journey works as a whole: https://github.com/ONSdigital/dp-compose/pull/13

Part of 5 PRs - Might be best if one person reviews all at once as they are designed to work together.

### Who can review

Anyone - If someone wants to review the whole journey that would be best. Minimum requirement test these changes don't stop the service running as it does as-is
