### PR TITLE
update cantabular recipe to parameters required for graphql

### DIFF
--- a/import-recipes/recipes.json
+++ b/import-recipes/recipes.json
@@ -14,16 +14,6 @@
           },
           {
             "href": "",
-            "id": "country",
-            "name": "Country"
-          },
-          {
-            "href": "",
-            "id": "siblings",
-            "name": "Number Of Siblings"
-          },
-          {
-            "href": "",
             "id": "siblings_3",
             "name": "Number Of Siblings (3 mappings)"
           },
@@ -37,7 +27,7 @@
         "editions": [
           "2021"
         ],
-        "title": "Example Cantabular Dataset City Siblings And Sex"
+        "title": "Example Cantabular Dataset City Siblings (3 mappings) And Sex"
       }
     ]
   },


### PR DESCRIPTION
### What

Upon working on the GraphQL query for pulling data for a static dataset it became apparent that a recipe that
pulls down all the variables is not suitable for making the appropriate query.

It's not fully understood the limitations on how many/which combinations of variables are allowed but asking for too many ends up in a `MAX_CELLS` GraphQL query.

This is a small change to reduce the size of the recipe to produce a query that Cantabular can happily respond to.

We will understand more as we get more realistic datasets.

### How to review

Check code change makes sense, is valid JSON.

### Who can review

Anyone
