### PR TITLE
is_cantabular_geography only required for cantbaular flexible table table

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -193,19 +193,19 @@ func (api *RecipeAPI) AddInstanceHandler(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	// Validation to check if all the instance fields are entered
-	err = instance.ValidateAddInstance(ctx)
-	if err != nil {
-		log.Error(ctx, "bad request error as invalid instance given in request body", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	// Get currentRecipe from ID given to get instance of the recipe
 	currentRecipe, err := api.dataStore.Backend.GetRecipe(ctx, recipeID)
 	if err != nil {
 		log.Error(ctx, "error retrieving specific recipe from mongo", err, logD)
 		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Validation to check if all the instance fields are entered
+	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable())
+	if err != nil {
+		log.Error(ctx, "bad request error as invalid instance given in request body", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -265,19 +265,19 @@ func (api *RecipeAPI) AddCodelistHandler(w http.ResponseWriter, req *http.Reques
 		codelist.HRef = models.HRefURL + codelist.ID
 	}
 
-	// Validation to check if all the instance fields are entered
-	err = codelist.ValidateAddCodelist(ctx)
-	if err != nil {
-		log.Error(ctx, "bad request error as invalid codelist given in request body", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	// Get currentRecipe from ID and retrieve specific instance for codelist to be stored
 	currentRecipe, err := api.dataStore.Backend.GetRecipe(ctx, recipeID)
 	if err != nil {
 		log.Error(ctx, "error retrieving specific recipe from mongo", err, logD)
 		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Validation to check if all the instance fields are entered
+	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable())
+	if err != nil {
+		log.Error(ctx, "bad request error as invalid codelist given in request body", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -384,19 +384,19 @@ func (api *RecipeAPI) UpdateInstanceHandler(w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	// Validation to check fields of instance and if all the code lists of the instance are entered if update of codelist given
-	err = updates.ValidateUpdateInstance(ctx)
-	if err != nil {
-		log.Error(ctx, "bad request error for invalid updates given in request body", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	// Find index of specific interface in output_instances of the recipe
 	currentRecipe, err := api.dataStore.Backend.GetRecipe(ctx, recipeID)
 	if err != nil {
 		log.Error(ctx, "error retrieving specific recipe from mongo", err, logD)
 		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Validation to check fields of instance and if all the code lists of the instance are entered if update of codelist given
+	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable())
+	if err != nil {
+		log.Error(ctx, "bad request error for invalid updates given in request body", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/handlers_test.go
+++ b/api/handlers_test.go
@@ -311,7 +311,7 @@ func TestAddInstanceReturnsBadRequestError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.UpdateRecipeCalls()), ShouldEqual, 0)
-		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 1)
 	})
 }
 
@@ -379,7 +379,7 @@ func TestUpdateInstanceReturnsBadRequest(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.UpdateInstanceCalls()), ShouldEqual, 0)
-		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 1)
 	})
 }
 
@@ -446,7 +446,7 @@ func TestAddCodelistReturnsBadRequestError(t *testing.T) {
 
 		So(w.Code, ShouldEqual, http.StatusBadRequest)
 		So(len(mockedDataStore.AddCodelistCalls()), ShouldEqual, 0)
-		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 0)
+		So(len(mockedDataStore.GetRecipeCalls()), ShouldEqual, 1)
 	})
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -63,8 +63,12 @@ var (
 	}
 )
 
+func (recipe *Recipe) IsCantabularFlexibleTable() bool {
+	return recipe.Format == "cantabular_flexible_table"
+}
+
 // validateInstance - checks if fields of OutputInstances are not empty for ValidateAddRecipe and ValidateAddInstance
-func (instance *Instance) validateInstance(ctx context.Context) (missingFields []string, invalidFields []string) {
+func (instance *Instance) validateInstance(ctx context.Context, isCantabularFlexibleTable bool) (missingFields []string, invalidFields []string) {
 
 	if instance.DatasetID == "" {
 		missingFields = append(missingFields, "dataset_id")
@@ -86,7 +90,7 @@ func (instance *Instance) validateInstance(ctx context.Context) (missingFields [
 
 	if instance.CodeLists != nil && len(instance.CodeLists) > 0 {
 		for i, codelist := range instance.CodeLists {
-			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx)
+			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx, isCantabularFlexibleTable)
 
 			if len(codelistMissingFields) > 0 {
 				for mIndex, mField := range codelistMissingFields {
@@ -110,7 +114,7 @@ func (instance *Instance) validateInstance(ctx context.Context) (missingFields [
 }
 
 // validateCodelists - checks if fields of CodeList are not empty for ValidateAddRecipe, ValidateAddInstance, ValidateAddCodelist
-func (codelist *CodeList) validateCodelist(ctx context.Context) (missingFields []string, invalidFields []string) {
+func (codelist *CodeList) validateCodelist(ctx context.Context, isCantabularFlexibleTable bool) (missingFields []string, invalidFields []string) {
 
 	if codelist.ID == "" {
 		missingFields = append(missingFields, "id")
@@ -132,7 +136,7 @@ func (codelist *CodeList) validateCodelist(ctx context.Context) (missingFields [
 		missingFields = append(missingFields, "isHierarchy")
 	}
 
-	if codelist.IsCantabularGeography == nil {
+	if codelist.IsCantabularGeography == nil && isCantabularFlexibleTable {
 		missingFields = append(missingFields, "isCantabularGeography")
 	}
 
@@ -198,7 +202,7 @@ func (recipe *Recipe) ValidateAddRecipe(ctx context.Context) error {
 
 	if recipe.OutputInstances != nil && len(recipe.OutputInstances) > 0 {
 		for i, instance := range recipe.OutputInstances {
-			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx)
+			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx, recipe.IsCantabularFlexibleTable())
 			if len(instanceMissingFields) > 0 {
 				for mIndex, mField := range instanceMissingFields {
 					instanceMissingFields[mIndex] = "output-instances[" + strconv.Itoa(i) + "]." + mField
@@ -229,11 +233,11 @@ func (recipe *Recipe) ValidateAddRecipe(ctx context.Context) error {
 }
 
 // ValidateAddInstance - checks if fields of OutputInstances are not empty
-func (instance *Instance) ValidateAddInstance(ctx context.Context) error {
+func (instance *Instance) ValidateAddInstance(ctx context.Context, isCantabularFlexibleTable bool) error {
 	var missingFields []string
 	var invalidFields []string
 
-	instanceMissingField, instanceInvalidField := instance.validateInstance(ctx)
+	instanceMissingField, instanceInvalidField := instance.validateInstance(ctx, isCantabularFlexibleTable)
 	missingFields = append(missingFields, instanceMissingField...)
 	invalidFields = append(invalidFields, instanceInvalidField...)
 
@@ -249,11 +253,11 @@ func (instance *Instance) ValidateAddInstance(ctx context.Context) error {
 }
 
 // ValidateAddCodelist - checks if fields of Codelist are not empty
-func (codelist *CodeList) ValidateAddCodelist(ctx context.Context) error {
+func (codelist *CodeList) ValidateAddCodelist(ctx context.Context, isCantabularFlexibleTable bool) error {
 	var missingFields []string
 	var invalidFields []string
 
-	codelistMissingFields, codelistinvalidFields := codelist.validateCodelist(ctx)
+	codelistMissingFields, codelistinvalidFields := codelist.validateCodelist(ctx, isCantabularFlexibleTable)
 	missingFields = append(missingFields, codelistMissingFields...)
 	invalidFields = append(invalidFields, codelistinvalidFields...)
 
@@ -304,7 +308,7 @@ func (recipe *Recipe) ValidateUpdateRecipe(ctx context.Context) error {
 	// This functionality is already available in validateInstance
 	if recipe.OutputInstances != nil && len(recipe.OutputInstances) > 0 {
 		for i, instance := range recipe.OutputInstances {
-			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx)
+			instanceMissingFields, instanceInvalidFields := instance.validateInstance(ctx, recipe.IsCantabularFlexibleTable())
 			if len(instanceMissingFields) > 0 {
 				for mIndex, mField := range instanceMissingFields {
 					instanceMissingFields[mIndex] = "output-instances[" + strconv.Itoa(i) + "]." + mField
@@ -336,7 +340,7 @@ func (recipe *Recipe) ValidateUpdateRecipe(ctx context.Context) error {
 }
 
 // ValidateUpdateInstance - checks fields of instance before updating the instance of the recipe
-func (instance *Instance) ValidateUpdateInstance(ctx context.Context) error {
+func (instance *Instance) ValidateUpdateInstance(ctx context.Context, isCantabularFlexibleTable bool) error {
 	var missingFields []string
 	var invalidFields []string
 
@@ -362,7 +366,7 @@ func (instance *Instance) ValidateUpdateInstance(ctx context.Context) error {
 	// This functionality is already available in validateCodelists
 	if instance.CodeLists != nil && len(instance.CodeLists) > 0 {
 		for i, codelist := range instance.CodeLists {
-			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx)
+			codelistMissingFields, codelistInvalidFields := codelist.validateCodelist(ctx, isCantabularFlexibleTable)
 			if len(codelistMissingFields) > 0 {
 				for mIndex, mField := range codelistMissingFields {
 					codelistMissingFields[mIndex] = "code-lists[" + strconv.Itoa(i) + "]." + mField

--- a/models/models.go
+++ b/models/models.go
@@ -140,7 +140,7 @@ func (codelist *CodeList) validateCodelist(ctx context.Context, isCantabularFlex
 		missingFields = append(missingFields, "isCantabularGeography")
 	}
 
-	if codelist.IsCantabularDefaultGeography == nil {
+	if codelist.IsCantabularDefaultGeography == nil && isCantabularFlexibleTable {
 		missingFields = append(missingFields, "isCantabularDefaultGeography")
 	}
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -55,7 +55,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when datasetID is missing", func() {
 			instance := createInstance()
 			instance.DatasetID = ""
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"dataset_id"})
 			So(invalidFields, ShouldBeNil)
@@ -64,7 +64,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = nil
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions"})
 			So(invalidFields, ShouldBeNil)
@@ -73,7 +73,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when an edition of editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = []string{""}
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions[0]"})
 			So(invalidFields, ShouldBeNil)
@@ -84,7 +84,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when title is missing", func() {
 			instance := createInstance()
 			instance.Title = ""
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"title"})
 			So(invalidFields, ShouldBeNil)
@@ -93,7 +93,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists = nil
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists"})
 			So(invalidFields, ShouldBeNil)
@@ -102,7 +102,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when any field of code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists[0].name"})
 			So(invalidFields, ShouldBeNil)
@@ -116,7 +116,7 @@ func TestValidateInstance(t *testing.T) {
 
 		Convey("when all fields are output-instances are given", func() {
 			instance := createInstance()
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -128,7 +128,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code-lists.href is incorrectly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"code-lists[0].href should be in format (URL/id)"})
@@ -143,7 +143,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code-lists.href is correctly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := instance.validateInstance(ctx)
+			missingFields, invalidFields := instance.validateInstance(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -162,7 +162,7 @@ func TestValidateCodelist(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"id"})
 			So(invalidFields, ShouldBeNil)
@@ -171,7 +171,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is missing", func() {
 			codelist := createCodeList()
 			codelist.HRef = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"href"})
 			So(invalidFields, ShouldBeNil)
@@ -180,7 +180,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when name is missing", func() {
 			codelist := createCodeList()
 			codelist.Name = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"name"})
 			So(invalidFields, ShouldBeNil)
@@ -189,7 +189,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when ishierarchy is missing", func() {
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isHierarchy"})
 			So(invalidFields, ShouldBeNil)
@@ -198,7 +198,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when isCantabularGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -207,7 +207,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularDefaultGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -219,7 +219,7 @@ func TestValidateCodelist(t *testing.T) {
 
 		Convey("when all fields are codelist are given", func() {
 			codelist := createCodeList()
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -231,7 +231,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is incorrectly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"href should be in format (URL/id)"})
@@ -244,7 +244,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is correctly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -639,7 +639,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when datasetID is missing", func() {
 			instance := createInstance()
 			instance.DatasetID = ""
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [dataset_id]").Error())
 		})
@@ -647,7 +647,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = nil
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 		})
@@ -655,7 +655,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when an edition of editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = []string{""}
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -665,7 +665,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when title is missing", func() {
 			instance := createInstance()
 			instance.Title = ""
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [title]").Error())
 		})
@@ -673,7 +673,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists = nil
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists]").Error())
 		})
@@ -681,7 +681,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when any field of code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -694,7 +694,7 @@ func TestValidateAddInstance(t *testing.T) {
 
 		Convey("when all fields are output-instances are given", func() {
 			instance := createInstance()
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -705,7 +705,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code-lists.href is incorrectly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -719,7 +719,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code-lists.href is correctly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			err := instance.ValidateAddInstance(ctx)
+			err := instance.ValidateAddInstance(ctx, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -734,7 +734,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when empty editions update is given", func() {
 			instance := Instance{Editions: []string{}}
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 
@@ -742,7 +742,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when any edition update of editions is incomplete", func() {
 			instance := Instance{Editions: []string{""}}
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -752,7 +752,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when any code lists fields is missing", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -763,7 +763,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when there are two code lists and second has error", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList(), createCodeList()}}
 			instance.CodeLists[1].Name = ""
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[1].name]").Error())
 
@@ -776,13 +776,13 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when complete editions update is given", func() {
 			instance := Instance{Editions: []string{"editions"}}
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("when all code lists fields are not missing", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -792,7 +792,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when no instance fields updates is given", func() {
 			instance := Instance{}
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [no instance fields updates given]").Error())
 		})
@@ -800,7 +800,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when any code lists fields is invalid", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateUpdateInstance(ctx)
+			err := instance.ValidateUpdateInstance(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -819,7 +819,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 					// createCodeList() is a complete and valid codelist
 					// instance just updating code lists of instance
 					instance := Instance{CodeLists: []CodeList{createCodeList()}}
-					err := instance.ValidateUpdateInstance(ctx)
+					err := instance.ValidateUpdateInstance(ctx, false)
 					So(err, ShouldBeNil)
 				})
 
@@ -841,7 +841,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [id]").Error())
 		})
@@ -849,7 +849,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is missing", func() {
 			codelist := createCodeList()
 			codelist.HRef = ""
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [href]").Error())
 		})
@@ -857,7 +857,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when name is missing", func() {
 			codelist := createCodeList()
 			codelist.Name = ""
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [name]").Error())
 		})
@@ -865,7 +865,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when ishierarchy is missing", func() {
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isHierarchy]").Error())
 		})
@@ -873,7 +873,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when isCantabularGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, true)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularGeography]").Error())
 		})
@@ -881,7 +881,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularDefaultGeography]").Error())
 		})
@@ -892,7 +892,7 @@ func TestValidateAddCodelists(t *testing.T) {
 
 		Convey("when all fields are codelist are given", func() {
 			codelist := createCodeList()
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -903,7 +903,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is incorrectly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [href should be in format (URL/id)]").Error())
 		})
@@ -915,7 +915,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is correctly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			err := codelist.ValidateAddCodelist(ctx)
+			err := codelist.ValidateAddCodelist(ctx, false)
 			So(err, ShouldBeNil)
 		})
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -207,7 +207,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularDefaultGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -881,7 +881,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, true)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularDefaultGeography]").Error())
 		})


### PR DESCRIPTION
### What

The "is-cantabular-geography" field should only be mandatory if the recipe type is of "cantabular-flexible-table"
Trello - https://trello.com/c/ZKQaTm63/5603-is-cantabular-geography-field-should-be-optional-in-dp-recipe-api

### How to review

Confirm changes are correct and make sense

### Who can review

Anyone
