### PR TITLE
Updated golang version and 'go get' to support 1.18

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,8 +1,8 @@
-FROM golang:1.16-stretch AS base
+FROM golang:1.18-stretch AS base
 
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
-RUN GOBIN=/bin go get github.com/cespare/reflex
+RUN GOBIN=/bin go install github.com/cespare/reflex@latest
 
 # Map between the working directories of dev and live
 RUN ln -s /go /dp-recipe-api


### PR DESCRIPTION
### What
We are seeing this error dp-recipe-api service 
HUMAN_LOG=1 go run -race -ldflags "-X main.BuildTime=1657281711 -X main.GitCommit=c73180d8496069f2f14d4b858b8ef4113f88bbd9 -X main.Version=v2.10.0" main.go

The fix is to move to the latest golang by updating the dockerfile 
### How to review

Check if the version matches the one in CI

### Who can review
Anyone
