### PR TITLE
Add validation to ensure the name and id are the same for cantabular imports

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -202,7 +202,7 @@ func (api *RecipeAPI) AddInstanceHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
+	err = instance.ValidateAddInstance(ctx, currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid instance given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -274,7 +274,7 @@ func (api *RecipeAPI) AddCodelistHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
+	err = codelist.ValidateAddCodelist(ctx, currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid codelist given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -393,7 +393,7 @@ func (api *RecipeAPI) UpdateInstanceHandler(w http.ResponseWriter, req *http.Req
 	}
 
 	// Validation to check fields of instance and if all the code lists of the instance are entered if update of codelist given
-	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
+	err = updates.ValidateUpdateInstance(ctx, currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error for invalid updates given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -202,7 +202,7 @@ func (api *RecipeAPI) AddInstanceHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
+	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid instance given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -274,7 +274,7 @@ func (api *RecipeAPI) AddCodelistHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
+	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid codelist given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -393,7 +393,7 @@ func (api *RecipeAPI) UpdateInstanceHandler(w http.ResponseWriter, req *http.Req
 	}
 
 	// Validation to check fields of instance and if all the code lists of the instance are entered if update of codelist given
-	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
+	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe)
 	if err != nil {
 		log.Error(ctx, "bad request error for invalid updates given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -202,7 +202,7 @@ func (api *RecipeAPI) AddInstanceHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable())
+	err = instance.ValidateAddInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid instance given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -274,7 +274,7 @@ func (api *RecipeAPI) AddCodelistHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	// Validation to check if all the instance fields are entered
-	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable())
+	err = codelist.ValidateAddCodelist(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
 	if err != nil {
 		log.Error(ctx, "bad request error as invalid codelist given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -393,7 +393,7 @@ func (api *RecipeAPI) UpdateInstanceHandler(w http.ResponseWriter, req *http.Req
 	}
 
 	// Validation to check fields of instance and if all the code lists of the instance are entered if update of codelist given
-	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable())
+	err = updates.ValidateUpdateInstance(ctx, currentRecipe.IsCantabularFlexibleTable(), currentRecipe.IsCantabularType())
 	if err != nil {
 		log.Error(ctx, "bad request error for invalid updates given in request body", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/models/models.go
+++ b/models/models.go
@@ -84,7 +84,7 @@ func (recipe *Recipe) IsCantabularType() bool {
 }
 
 // validateInstance - checks if fields of OutputInstances are not empty for ValidateAddRecipe and ValidateAddInstance
-func (instance *Instance) validateInstance(ctx context.Context, isCantabularFlexibleTable, isCantabularType bool) (missingFields []string, invalidFields []string) {
+func (instance *Instance) validateInstance(ctx context.Context, isCantabularFlexibleTable bool, recipe *Recipe) (missingFields []string, invalidFields []string) {
 	if instance.DatasetID == "" {
 		missingFields = append(missingFields, "dataset_id")
 	}
@@ -105,7 +105,7 @@ func (instance *Instance) validateInstance(ctx context.Context, isCantabularFlex
 
 	if instance.CodeLists != nil && len(instance.CodeLists) > 0 {
 		for i, codelist := range instance.CodeLists {
-			missing, invalid := codelist.validateCodelist(ctx, isCantabularFlexibleTable, isCantabularType)
+			missing, invalid := codelist.validateCodelist(ctx, isCantabularFlexibleTable, recipe)
 
 			if len(missing) > 0 {
 				for j, field := range missing {
@@ -129,7 +129,7 @@ func (instance *Instance) validateInstance(ctx context.Context, isCantabularFlex
 }
 
 // validateCodelists - checks if fields of CodeList are not empty for ValidateAddRecipe, ValidateAddInstance, ValidateAddCodelist
-func (c *CodeList) validateCodelist(ctx context.Context, isCantabularFlexibleTable, isCantabularType bool) (missingFields []string, invalidFields []string) {
+func (c *CodeList) validateCodelist(ctx context.Context, isCantabularFlexibleTable bool, recipe *Recipe) (missingFields []string, invalidFields []string) {
 	if c.ID == "" {
 		missingFields = append(missingFields, "id")
 	}
@@ -146,7 +146,7 @@ func (c *CodeList) validateCodelist(ctx context.Context, isCantabularFlexibleTab
 		missingFields = append(missingFields, "name")
 	}
 
-	if isCantabularType && c.Name != c.ID {
+	if recipe.IsCantabularType() && c.Name != c.ID {
 		invalidFields = append(invalidFields, "name and id should be matching values")
 	}
 
@@ -214,7 +214,7 @@ func (r *Recipe) ValidateAddRecipe(ctx context.Context) error {
 
 	if r.OutputInstances != nil && len(r.OutputInstances) > 0 {
 		for i, instance := range r.OutputInstances {
-			missing, invalid := instance.validateInstance(ctx, r.IsCantabularFlexibleTable(), r.IsCantabularType())
+			missing, invalid := instance.validateInstance(ctx, r.IsCantabularFlexibleTable(), r)
 			if len(missing) > 0 {
 				for j, field := range missing {
 					missing[j] = "output-instances[" + strconv.Itoa(i) + "]." + field
@@ -244,10 +244,10 @@ func (r *Recipe) ValidateAddRecipe(ctx context.Context) error {
 }
 
 // ValidateAddInstance - checks if fields of OutputInstances are not empty
-func (instance *Instance) ValidateAddInstance(ctx context.Context, isCantabularFlexibleTable, isCantabularType bool) error {
+func (instance *Instance) ValidateAddInstance(ctx context.Context, isCantabularFlexibleTable bool, recipe *Recipe) error {
 	var missingFields, invalidFields []string
 
-	missing, invalid := instance.validateInstance(ctx, isCantabularFlexibleTable, isCantabularType)
+	missing, invalid := instance.validateInstance(ctx, isCantabularFlexibleTable, recipe)
 	missingFields = append(missingFields, missing...)
 	invalidFields = append(invalidFields, invalid...)
 
@@ -263,10 +263,10 @@ func (instance *Instance) ValidateAddInstance(ctx context.Context, isCantabularF
 }
 
 // ValidateAddCodelist - checks if fields of Codelist are not empty
-func (c *CodeList) ValidateAddCodelist(ctx context.Context, isCantabularFlexibleTable, isCantabularType bool) error {
+func (c *CodeList) ValidateAddCodelist(ctx context.Context, isCantabularFlexibleTable bool, recipe *Recipe) error {
 	var missingFields, invalidFields []string
 
-	missing, invalid := c.validateCodelist(ctx, isCantabularFlexibleTable, isCantabularType)
+	missing, invalid := c.validateCodelist(ctx, isCantabularFlexibleTable, recipe)
 	missingFields = append(missingFields, missing...)
 	invalidFields = append(invalidFields, invalid...)
 
@@ -316,7 +316,7 @@ func (r *Recipe) ValidateUpdateRecipe(ctx context.Context) error {
 	// This functionality is already available in validateInstance
 	if r.OutputInstances != nil && len(r.OutputInstances) > 0 {
 		for i, instance := range r.OutputInstances {
-			missing, invalid := instance.validateInstance(ctx, r.IsCantabularFlexibleTable(), r.IsCantabularType())
+			missing, invalid := instance.validateInstance(ctx, r.IsCantabularFlexibleTable(), r)
 			if len(missing) > 0 {
 				for j, field := range missing {
 					missing[j] = "output-instances[" + strconv.Itoa(i) + "]." + field
@@ -348,7 +348,7 @@ func (r *Recipe) ValidateUpdateRecipe(ctx context.Context) error {
 }
 
 // ValidateUpdateInstance - checks fields of instance before updating the instance of the recipe
-func (instance *Instance) ValidateUpdateInstance(ctx context.Context, isCantabularFlexibleTable, isCantabularType bool) error {
+func (instance *Instance) ValidateUpdateInstance(ctx context.Context, isCantabularFlexibleTable bool, recipe *Recipe) error {
 	var missingFields, invalidFields []string
 
 	// Validation to check if at least one instance field is updated
@@ -373,7 +373,7 @@ func (instance *Instance) ValidateUpdateInstance(ctx context.Context, isCantabul
 	// This functionality is already available in validateCodelists
 	if instance.CodeLists != nil && len(instance.CodeLists) > 0 {
 		for i, codelist := range instance.CodeLists {
-			missing, invalid := codelist.validateCodelist(ctx, isCantabularFlexibleTable, isCantabularType)
+			missing, invalid := codelist.validateCodelist(ctx, isCantabularFlexibleTable, recipe)
 			if len(missing) > 0 {
 				for j, field := range missing {
 					missing[j] = "code-lists[" + strconv.Itoa(i) + "]." + field

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -56,7 +56,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.DatasetID = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"dataset_id"})
 			So(invalidFields, ShouldBeNil)
@@ -66,7 +66,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions"})
 			So(invalidFields, ShouldBeNil)
@@ -76,7 +76,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = []string{""}
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions[0]"})
 			So(invalidFields, ShouldBeNil)
@@ -88,7 +88,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Title = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"title"})
 			So(invalidFields, ShouldBeNil)
@@ -98,7 +98,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists"})
 			So(invalidFields, ShouldBeNil)
@@ -108,7 +108,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists[0].name"})
 			So(invalidFields, ShouldBeNil)
@@ -123,7 +123,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when all fields are output-instances are given", func() {
 			recipe := createRecipeData()
 			instance := createInstance()
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -136,7 +136,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"code-lists[0].href should be in format (URL/id)"})
@@ -152,7 +152,7 @@ func TestValidateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
+			missingFields, invalidFields := instance.validateInstance(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -172,7 +172,7 @@ func TestValidateCodelist(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"id"})
 			So(invalidFields, ShouldBeNil)
@@ -182,7 +182,7 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"href"})
 			So(invalidFields, ShouldBeNil)
@@ -192,7 +192,7 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.Name = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"name"})
 			So(invalidFields, ShouldBeNil)
@@ -202,7 +202,7 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isHierarchy"})
 			So(invalidFields, ShouldBeNil)
@@ -212,7 +212,8 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true, &recipe)
+			recipe.Format = "cantabular_flexible_table"
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -222,7 +223,8 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true, &recipe)
+			recipe.Format = "cantabular_flexible_table"
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularDefaultGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -235,7 +237,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when all fields are codelist are given", func() {
 			recipe := createRecipeData()
 			codelist := createCodeList()
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -248,7 +250,7 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"href should be in format (URL/id)"})
@@ -261,7 +263,7 @@ func TestValidateCodelist(t *testing.T) {
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "123"
 			codelist.ID = "789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"name and id should be matching values"})
@@ -275,7 +277,7 @@ func TestValidateCodelist(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -287,7 +289,7 @@ func TestValidateCodelist(t *testing.T) {
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "789"
 			codelist.ID = "789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -706,7 +708,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.DatasetID = ""
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [dataset_id]").Error())
 		})
@@ -715,7 +717,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = nil
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 		})
@@ -724,7 +726,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = []string{""}
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -735,7 +737,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Title = ""
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [title]").Error())
 		})
@@ -744,7 +746,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists = nil
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists]").Error())
 		})
@@ -753,7 +755,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -767,7 +769,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when all fields are output-instances are given", func() {
 			recipe := createRecipeData()
 			instance := createInstance()
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -779,7 +781,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -794,7 +796,7 @@ func TestValidateAddInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			err := instance.ValidateAddInstance(ctx, false, &recipe)
+			err := instance.ValidateAddInstance(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -810,7 +812,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when empty editions update is given", func() {
 			recipe := createRecipeData()
 			instance := Instance{Editions: []string{}}
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 
@@ -819,7 +821,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when any edition update of editions is incomplete", func() {
 			recipe := createRecipeData()
 			instance := Instance{Editions: []string{""}}
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -830,7 +832,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -842,7 +844,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList(), createCodeList()}}
 			instance.CodeLists[1].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[1].name]").Error())
 
@@ -856,14 +858,14 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when complete editions update is given", func() {
 			recipe := createRecipeData()
 			instance := Instance{Editions: []string{"editions"}}
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("when all code lists fields are not missing", func() {
 			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -874,7 +876,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when no instance fields updates is given", func() {
 			recipe := createRecipeData()
 			instance := Instance{}
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [no instance fields updates given]").Error())
 		})
@@ -883,7 +885,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+			err := instance.ValidateUpdateInstance(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -903,7 +905,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 					// instance just updating code lists of instance
 					recipe := createRecipeData()
 					instance := Instance{CodeLists: []CodeList{createCodeList()}}
-					err := instance.ValidateUpdateInstance(ctx, false, &recipe)
+					err := instance.ValidateUpdateInstance(ctx, &recipe)
 					So(err, ShouldBeNil)
 				})
 
@@ -926,7 +928,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [id]").Error())
 		})
@@ -935,7 +937,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = ""
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [href]").Error())
 		})
@@ -944,7 +946,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.Name = ""
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [name]").Error())
 		})
@@ -953,7 +955,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isHierarchy]").Error())
 		})
@@ -962,7 +964,8 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true, &recipe)
+			recipe.Format = "cantabular_flexible_table"
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularGeography]").Error())
 		})
@@ -971,7 +974,8 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true, &recipe)
+			recipe.Format = "cantabular_flexible_table"
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularDefaultGeography]").Error())
 		})
@@ -983,7 +987,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when all fields are codelist are given", func() {
 			recipe := createRecipeData()
 			codelist := createCodeList()
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -995,7 +999,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [href should be in format (URL/id)]").Error())
 		})
@@ -1008,7 +1012,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
+			err := codelist.ValidateAddCodelist(ctx, &recipe)
 			So(err, ShouldBeNil)
 		})
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -237,23 +237,7 @@ func TestValidateCodelist(t *testing.T) {
 			So(invalidFields, ShouldResemble, []string{"href should be in format (URL/id)"})
 		})
 
-	})
-
-	Convey("Empty invalid field successfully returned", t, func() {
-
-		Convey("when href is correctly entered", func() {
-			codelist := createCodeList()
-			codelist.HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
-			So(missingFields, ShouldBeNil)
-			So(invalidFields, ShouldBeNil)
-		})
-
-	})
-
-	Convey("Non-empty invalid field successfully returned - id and name not matching", t, func() {
-
-		Convey("when href is incorrectly entered", func() {
+		Convey("when name and id fields do not match", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "123"
@@ -266,9 +250,17 @@ func TestValidateCodelist(t *testing.T) {
 
 	})
 
-	Convey("Empty invalid field successfully returned - id and name matching", t, func() {
+	Convey("Empty invalid field successfully returned", t, func() {
 
-		Convey("when href is incorrectly entered", func() {
+		Convey("when href is correctly entered", func() {
+			codelist := createCodeList()
+			codelist.HRef = "http://localhost:22400/code-lists/789"
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			So(missingFields, ShouldBeNil)
+			So(invalidFields, ShouldBeNil)
+		})
+
+		Convey("when name and id fields do match", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "789"
@@ -279,7 +271,6 @@ func TestValidateCodelist(t *testing.T) {
 		})
 
 	})
-
 }
 
 func TestValidateCodelistHRef(t *testing.T) {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -19,7 +19,7 @@ var (
 func createCodeList() CodeList {
 	return CodeList{
 		ID:                           "789",
-		Name:                         "codelist-test",
+		Name:                         "789",
 		HRef:                         "http://localhost:22400/code-lists/789",
 		IsHierarchy:                  falseValPtr,
 		IsCantabularGeography:        falseValPtr,
@@ -55,7 +55,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when datasetID is missing", func() {
 			instance := createInstance()
 			instance.DatasetID = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"dataset_id"})
 			So(invalidFields, ShouldBeNil)
@@ -64,7 +64,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions"})
 			So(invalidFields, ShouldBeNil)
@@ -73,7 +73,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when an edition of editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = []string{""}
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions[0]"})
 			So(invalidFields, ShouldBeNil)
@@ -84,7 +84,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when title is missing", func() {
 			instance := createInstance()
 			instance.Title = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"title"})
 			So(invalidFields, ShouldBeNil)
@@ -93,7 +93,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists"})
 			So(invalidFields, ShouldBeNil)
@@ -102,7 +102,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when any field of code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists[0].name"})
 			So(invalidFields, ShouldBeNil)
@@ -116,7 +116,7 @@ func TestValidateInstance(t *testing.T) {
 
 		Convey("when all fields are output-instances are given", func() {
 			instance := createInstance()
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -128,7 +128,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code-lists.href is incorrectly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"code-lists[0].href should be in format (URL/id)"})
@@ -143,7 +143,7 @@ func TestValidateInstance(t *testing.T) {
 		Convey("when code-lists.href is correctly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := instance.validateInstance(ctx, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -162,7 +162,7 @@ func TestValidateCodelist(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"id"})
 			So(invalidFields, ShouldBeNil)
@@ -171,7 +171,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is missing", func() {
 			codelist := createCodeList()
 			codelist.HRef = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"href"})
 			So(invalidFields, ShouldBeNil)
@@ -180,7 +180,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when name is missing", func() {
 			codelist := createCodeList()
 			codelist.Name = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"name"})
 			So(invalidFields, ShouldBeNil)
@@ -189,7 +189,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when ishierarchy is missing", func() {
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isHierarchy"})
 			So(invalidFields, ShouldBeNil)
@@ -198,7 +198,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when isCantabularGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true, true)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -207,7 +207,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true, true)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularDefaultGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -219,7 +219,7 @@ func TestValidateCodelist(t *testing.T) {
 
 		Convey("when all fields are codelist are given", func() {
 			codelist := createCodeList()
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -231,7 +231,7 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is incorrectly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"href should be in format (URL/id)"})
@@ -244,7 +244,36 @@ func TestValidateCodelist(t *testing.T) {
 		Convey("when href is correctly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			So(missingFields, ShouldBeNil)
+			So(invalidFields, ShouldBeNil)
+		})
+
+	})
+
+	Convey("Non-empty invalid field successfully returned - id and name not matching", t, func() {
+
+		Convey("when href is incorrectly entered", func() {
+			codelist := createCodeList()
+			codelist.HRef = "http://localhost:22400/code-lists/789"
+			codelist.Name = "123"
+			codelist.ID = "789"
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, true)
+			So(missingFields, ShouldBeNil)
+			So(invalidFields, ShouldNotBeNil)
+			So(invalidFields, ShouldResemble, []string{"name and id should be matching values"})
+		})
+
+	})
+
+	Convey("Empty invalid field successfully returned - id and name matching", t, func() {
+
+		Convey("when href is incorrectly entered", func() {
+			codelist := createCodeList()
+			codelist.HRef = "http://localhost:22400/code-lists/789"
+			codelist.Name = "789"
+			codelist.ID = "789"
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, true)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -663,7 +692,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when datasetID is missing", func() {
 			instance := createInstance()
 			instance.DatasetID = ""
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [dataset_id]").Error())
 		})
@@ -671,7 +700,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = nil
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 		})
@@ -679,7 +708,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when an edition of editions is missing", func() {
 			instance := createInstance()
 			instance.Editions = []string{""}
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -689,7 +718,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when title is missing", func() {
 			instance := createInstance()
 			instance.Title = ""
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [title]").Error())
 		})
@@ -697,7 +726,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists = nil
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists]").Error())
 		})
@@ -705,7 +734,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when any field of code lists is missing", func() {
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -718,7 +747,7 @@ func TestValidateAddInstance(t *testing.T) {
 
 		Convey("when all fields are output-instances are given", func() {
 			instance := createInstance()
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -729,7 +758,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code-lists.href is incorrectly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -743,7 +772,7 @@ func TestValidateAddInstance(t *testing.T) {
 		Convey("when code-lists.href is correctly entered", func() {
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			err := instance.ValidateAddInstance(ctx, false)
+			err := instance.ValidateAddInstance(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -758,7 +787,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when empty editions update is given", func() {
 			instance := Instance{Editions: []string{}}
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 
@@ -766,7 +795,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when any edition update of editions is incomplete", func() {
 			instance := Instance{Editions: []string{""}}
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -776,7 +805,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when any code lists fields is missing", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -787,7 +816,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when there are two code lists and second has error", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList(), createCodeList()}}
 			instance.CodeLists[1].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[1].name]").Error())
 
@@ -800,13 +829,13 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when complete editions update is given", func() {
 			instance := Instance{Editions: []string{"editions"}}
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("when all code lists fields are not missing", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -816,7 +845,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		Convey("when no instance fields updates is given", func() {
 			instance := Instance{}
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [no instance fields updates given]").Error())
 		})
@@ -824,7 +853,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 		Convey("when any code lists fields is invalid", func() {
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateUpdateInstance(ctx, false)
+			err := instance.ValidateUpdateInstance(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -843,7 +872,7 @@ func TestValidateUpdateInstance(t *testing.T) {
 					// createCodeList() is a complete and valid codelist
 					// instance just updating code lists of instance
 					instance := Instance{CodeLists: []CodeList{createCodeList()}}
-					err := instance.ValidateUpdateInstance(ctx, false)
+					err := instance.ValidateUpdateInstance(ctx, false, false)
 					So(err, ShouldBeNil)
 				})
 
@@ -865,7 +894,7 @@ func TestValidateAddCodelists(t *testing.T) {
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [id]").Error())
 		})
@@ -873,7 +902,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is missing", func() {
 			codelist := createCodeList()
 			codelist.HRef = ""
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [href]").Error())
 		})
@@ -881,7 +910,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when name is missing", func() {
 			codelist := createCodeList()
 			codelist.Name = ""
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [name]").Error())
 		})
@@ -889,7 +918,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when ishierarchy is missing", func() {
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isHierarchy]").Error())
 		})
@@ -897,7 +926,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when isCantabularGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true)
+			err := codelist.ValidateAddCodelist(ctx, true, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularGeography]").Error())
 		})
@@ -905,7 +934,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when isCantabularDefaultGeography is missing", func() {
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true)
+			err := codelist.ValidateAddCodelist(ctx, true, true)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularDefaultGeography]").Error())
 		})
@@ -916,7 +945,7 @@ func TestValidateAddCodelists(t *testing.T) {
 
 		Convey("when all fields are codelist are given", func() {
 			codelist := createCodeList()
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 
@@ -927,7 +956,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is incorrectly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [href should be in format (URL/id)]").Error())
 		})
@@ -939,7 +968,7 @@ func TestValidateAddCodelists(t *testing.T) {
 		Convey("when href is correctly entered", func() {
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			err := codelist.ValidateAddCodelist(ctx, false)
+			err := codelist.ValidateAddCodelist(ctx, false, false)
 			So(err, ShouldBeNil)
 		})
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -53,27 +53,30 @@ func TestValidateInstance(t *testing.T) {
 	Convey("Non-empty missing field successfully returned", t, func() {
 
 		Convey("when datasetID is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.DatasetID = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"dataset_id"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when editions is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when an edition of editions is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = []string{""}
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"editions[0]"})
 			So(invalidFields, ShouldBeNil)
@@ -82,27 +85,30 @@ func TestValidateInstance(t *testing.T) {
 		})
 
 		Convey("when title is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Title = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"title"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when code lists is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists = nil
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when any field of code lists is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"code-lists[0].name"})
 			So(invalidFields, ShouldBeNil)
@@ -115,8 +121,9 @@ func TestValidateInstance(t *testing.T) {
 	Convey("Empty missing field successfully returned", t, func() {
 
 		Convey("when all fields are output-instances are given", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -126,9 +133,10 @@ func TestValidateInstance(t *testing.T) {
 	Convey("Non-empty invalid field successfully returned", t, func() {
 
 		Convey("when code-lists.href is incorrectly entered", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"code-lists[0].href should be in format (URL/id)"})
@@ -141,9 +149,10 @@ func TestValidateInstance(t *testing.T) {
 	Convey("Empty invalid field successfully returned", t, func() {
 
 		Convey("when code-lists.href is correctly entered", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := instance.validateInstance(ctx, false, false)
+			missingFields, invalidFields := instance.validateInstance(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -158,56 +167,62 @@ func TestValidateCodelist(t *testing.T) {
 	Convey("Non-empty missing field successfully returned", t, func() {
 
 		Convey("when id is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"id"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when href is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"href"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when name is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.Name = ""
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"name"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when ishierarchy is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isHierarchy"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when isCantabularGeography is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularGeography"})
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when isCantabularDefaultGeography is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			missingFields, invalidFields := codelist.validateCodelist(ctx, true, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, true, &recipe)
 			So(missingFields, ShouldNotBeNil)
 			So(missingFields, ShouldResemble, []string{"isCantabularDefaultGeography"})
 			So(invalidFields, ShouldBeNil)
@@ -218,8 +233,9 @@ func TestValidateCodelist(t *testing.T) {
 	Convey("Empty missing field successfully returned", t, func() {
 
 		Convey("when all fields are codelist are given", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -229,20 +245,23 @@ func TestValidateCodelist(t *testing.T) {
 	Convey("Non-empty invalid field successfully returned", t, func() {
 
 		Convey("when href is incorrectly entered", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"href should be in format (URL/id)"})
 		})
 
 		Convey("when name and id fields do not match", func() {
+			recipe := createRecipeData()
+			recipe.Format = "cantabular_flexible_table"
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "123"
 			codelist.ID = "789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldNotBeNil)
 			So(invalidFields, ShouldResemble, []string{"name and id should be matching values"})
@@ -253,19 +272,22 @@ func TestValidateCodelist(t *testing.T) {
 	Convey("Empty invalid field successfully returned", t, func() {
 
 		Convey("when href is correctly entered", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, false)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
 
 		Convey("when name and id fields do match", func() {
+			recipe := createRecipeData()
+			recipe.Format = "cantabular_flexible_table"
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
 			codelist.Name = "789"
 			codelist.ID = "789"
-			missingFields, invalidFields := codelist.validateCodelist(ctx, false, true)
+			missingFields, invalidFields := codelist.validateCodelist(ctx, false, &recipe)
 			So(missingFields, ShouldBeNil)
 			So(invalidFields, ShouldBeNil)
 		})
@@ -681,25 +703,28 @@ func TestValidateAddInstance(t *testing.T) {
 	Convey("Non-empty missing field successfully returned", t, func() {
 
 		Convey("when datasetID is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.DatasetID = ""
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [dataset_id]").Error())
 		})
 
 		Convey("when editions is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = nil
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 		})
 
 		Convey("when an edition of editions is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Editions = []string{""}
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -707,25 +732,28 @@ func TestValidateAddInstance(t *testing.T) {
 		})
 
 		Convey("when title is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.Title = ""
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [title]").Error())
 		})
 
 		Convey("when code lists is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists = nil
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists]").Error())
 		})
 
 		Convey("when any field of code lists is missing", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -737,8 +765,9 @@ func TestValidateAddInstance(t *testing.T) {
 	Convey("Empty missing field successfully returned", t, func() {
 
 		Convey("when all fields are output-instances are given", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -747,9 +776,10 @@ func TestValidateAddInstance(t *testing.T) {
 	Convey("Non-empty invalid field successfully returned", t, func() {
 
 		Convey("when code-lists.href is incorrectly entered", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -761,9 +791,10 @@ func TestValidateAddInstance(t *testing.T) {
 	Convey("Empty invalid field successfully returned", t, func() {
 
 		Convey("when code-lists.href is correctly entered", func() {
+			recipe := createRecipeData()
 			instance := createInstance()
 			instance.CodeLists[0].HRef = "http://localhost:22400/code-lists/789"
-			err := instance.ValidateAddInstance(ctx, false, false)
+			err := instance.ValidateAddInstance(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -777,16 +808,18 @@ func TestValidateUpdateInstance(t *testing.T) {
 	Convey("Error returned with missing field", t, func() {
 
 		Convey("when empty editions update is given", func() {
+			recipe := createRecipeData()
 			instance := Instance{Editions: []string{}}
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions]").Error())
 
 		})
 
 		Convey("when any edition update of editions is incomplete", func() {
+			recipe := createRecipeData()
 			instance := Instance{Editions: []string{""}}
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [editions[0]]").Error())
 
@@ -794,9 +827,10 @@ func TestValidateUpdateInstance(t *testing.T) {
 		})
 
 		Convey("when any code lists fields is missing", func() {
+			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[0].name]").Error())
 
@@ -805,9 +839,10 @@ func TestValidateUpdateInstance(t *testing.T) {
 
 		// test fix: non-existant codelistMissingFields[1] was assigned to, instead of [0] - causing panic
 		Convey("when there are two code lists and second has error", func() {
+			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList(), createCodeList()}}
 			instance.CodeLists[1].Name = ""
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [code-lists[1].name]").Error())
 
@@ -819,14 +854,16 @@ func TestValidateUpdateInstance(t *testing.T) {
 	Convey("Successful with no missing fields (nil error returned)", t, func() {
 
 		Convey("when complete editions update is given", func() {
+			recipe := createRecipeData()
 			instance := Instance{Editions: []string{"editions"}}
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("when all code lists fields are not missing", func() {
+			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -835,16 +872,18 @@ func TestValidateUpdateInstance(t *testing.T) {
 	Convey("Error returned with invalid field", t, func() {
 
 		Convey("when no instance fields updates is given", func() {
+			recipe := createRecipeData()
 			instance := Instance{}
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [no instance fields updates given]").Error())
 		})
 
 		Convey("when any code lists fields is invalid", func() {
+			recipe := createRecipeData()
 			instance := Instance{CodeLists: []CodeList{createCodeList()}}
 			instance.CodeLists[0].HRef = "incorrect-href"
-			err := instance.ValidateUpdateInstance(ctx, false, false)
+			err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [code-lists[0].href should be in format (URL/id)]").Error())
 
@@ -862,8 +901,9 @@ func TestValidateUpdateInstance(t *testing.T) {
 				Convey("and any code lists fields is valid", func() {
 					// createCodeList() is a complete and valid codelist
 					// instance just updating code lists of instance
+					recipe := createRecipeData()
 					instance := Instance{CodeLists: []CodeList{createCodeList()}}
-					err := instance.ValidateUpdateInstance(ctx, false, false)
+					err := instance.ValidateUpdateInstance(ctx, false, &recipe)
 					So(err, ShouldBeNil)
 				})
 
@@ -881,51 +921,57 @@ func TestValidateAddCodelists(t *testing.T) {
 	Convey("Non-empty missing field successfully returned", t, func() {
 
 		Convey("when id is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.ID = ""
 			// HRef Updated as the format of HRef follows the value from ID
 			codelist.HRef = "http://localhost:22400/code-lists/"
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [id]").Error())
 		})
 
 		Convey("when href is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = ""
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [href]").Error())
 		})
 
 		Convey("when name is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.Name = ""
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [name]").Error())
 		})
 
 		Convey("when ishierarchy is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsHierarchy = nil
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isHierarchy]").Error())
 		})
 
 		Convey("when isCantabularGeography is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true, false)
+			err := codelist.ValidateAddCodelist(ctx, true, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularGeography]").Error())
 		})
 
 		Convey("when isCantabularDefaultGeography is missing", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.IsCantabularDefaultGeography = nil
-			err := codelist.ValidateAddCodelist(ctx, true, true)
+			err := codelist.ValidateAddCodelist(ctx, true, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("missing mandatory fields: [isCantabularDefaultGeography]").Error())
 		})
@@ -935,8 +981,9 @@ func TestValidateAddCodelists(t *testing.T) {
 	Convey("Empty missing field successfully returned", t, func() {
 
 		Convey("when all fields are codelist are given", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 
@@ -945,9 +992,10 @@ func TestValidateAddCodelists(t *testing.T) {
 	Convey("Non-empty invalid field successfully returned", t, func() {
 
 		Convey("when href is incorrectly entered", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "incorrect-href"
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldResemble, errors.New("invalid fields: [href should be in format (URL/id)]").Error())
 		})
@@ -957,9 +1005,10 @@ func TestValidateAddCodelists(t *testing.T) {
 	Convey("Empty invalid field successfully returned", t, func() {
 
 		Convey("when href is correctly entered", func() {
+			recipe := createRecipeData()
 			codelist := createCodeList()
 			codelist.HRef = "http://localhost:22400/code-lists/789"
-			err := codelist.ValidateAddCodelist(ctx, false, false)
+			err := codelist.ValidateAddCodelist(ctx, false, &recipe)
 			So(err, ShouldBeNil)
 		})
 


### PR DESCRIPTION
### What

Add validation to ensure the name and id are the same for cantabular imports
Trello - https://trello.com/c/p00tKqZR/5869-add-validation-to-dp-recipe-api-to-ensure-the-name-and-id-are-the-same-for-cantabular-imports

### How to review

Confirm changes match requested changes in Trello ticket

### Who can review

Anyone
